### PR TITLE
fix ratelimiting

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,14 +3,20 @@ from sqlite3 import DatabaseError
 
 from flask import Flask, render_template, request, send_from_directory, send_file
 from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
 import base64
 import json
 import libraries
 
+def get_remote_address():
+    return request.headers.get("CF-Connecting-IP", request.remote_addr)
+
 app = Flask(__name__)
 limiter = Limiter(app, key_func=get_remote_address, default_limits=["10 per minute"],
                   strategy="fixed-window-elastic-expiry", headers_enabled=True)
+
+@limiter.request_filter
+def ip_whitelist():
+    return request.remote_addr == ""
 
 
 @app.route('/')
@@ -25,11 +31,6 @@ def get_ip():  # InCase Request IP Needed
     else:
         ip = request.environ['HTTP_X_FORWARDED_FOR']
     return ip
-
-
-@limiter.request_filter
-def ip_whitelist():
-    return request.remote_addr == "188.114.97.18" or request.remote_addr == "127.0.0.1" or request.remote_addr == ""
 
 
 @app.route('/scripts')


### PR DESCRIPTION
+ Add a custom get_remote_address function that tries to get cloudflare connecting ip header or defaults to remote_addr

this pr should fix the issues with ratelimiting not working correctly on the production server, cloudflare proxies all the requests through their servers so all requests come from cloudflare, this pr changes the way the remote address is retrieved by using a header attached by cloudflare that contains the visitors original ip.

if this doesnt work, i give up