### PR TITLE
Run isort across all Python imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,26 +1,24 @@
-from functools import update_wrapper, wraps
-import os
-from pprint import pprint
-from sqlite3 import DatabaseError
-from flask import Flask, flash, jsonify, make_response, redirect, render_template, request, send_from_directory, send_file, session
-from flask_login import (
-    LoginManager,
-    current_user,
-    login_user,
-    logout_user,
-)
-from oauthlib.oauth2 import WebApplicationClient
 import base64
 import json
+import os
+from functools import update_wrapper, wraps
+from pprint import pprint
+from sqlite3 import DatabaseError
+
 import requests
-from config import API_HOST, API_PORT
-import libraries
+from dunamai import Style, Version
+from flask import (Flask, flash, jsonify, make_response, redirect,
+                   render_template, request, send_file, send_from_directory,
+                   session)
+from flask_login import LoginManager, current_user, login_user, logout_user
+from oauthlib.oauth2 import WebApplicationClient
+from werkzeug.exceptions import (BadRequest, Forbidden, HTTPException,
+                                 Unauthorized)
 from werkzeug.middleware.proxy_fix import ProxyFix
-from werkzeug.exceptions import HTTPException, Forbidden, BadRequest, Unauthorized
 
+import libraries
+from config import API_HOST, API_PORT
 from utils import APIAction, construct_logger
-
-from dunamai import Version, Style
 
 app = Flask(__name__, instance_relative_config=True)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)

--- a/libraries.py
+++ b/libraries.py
@@ -1,15 +1,16 @@
-import logging
-from flask_login import UserMixin
-import sqlite3
-import requests
 import base64
 import json
-from flask import render_template, Response
-import time
-import yaml
+import logging
 import random
 import secrets
-from werkzeug.exceptions import Forbidden, BadRequest
+import sqlite3
+import time
+
+import requests
+import yaml
+from flask import Response, render_template
+from flask_login import UserMixin
+from werkzeug.exceptions import BadRequest, Forbidden
 
 from config import APPENDERS, DEFAULT_CDMS, GUILD_ID, VERIFIED_ROLE_ID
 from instance.config import OAUTH2_CLIENT_ID, OAUTH2_CLIENT_SECRET

--- a/pywidevine/cdm/cdm.py
+++ b/pywidevine/cdm/cdm.py
@@ -1,23 +1,22 @@
 import base64
-
+import binascii
+import logging
 import os
 import time
-import binascii
 
-from google.protobuf.message import DecodeError
-from google.protobuf import text_format
-
-from pywidevine.cdm.formats import wv_proto2_pb2 as wv_proto2
-from pywidevine.cdm.session import Session
-from pywidevine.cdm.key import Key
-from Cryptodome.Random import get_random_bytes
-from Cryptodome.Random import random
-from Cryptodome.Cipher import PKCS1_OAEP, AES
-from Cryptodome.Hash import CMAC, SHA256, HMAC, SHA1
+from Cryptodome.Cipher import AES, PKCS1_OAEP
+from Cryptodome.Hash import CMAC, HMAC, SHA1, SHA256
 from Cryptodome.PublicKey import RSA
+from Cryptodome.Random import get_random_bytes, random
 from Cryptodome.Signature import pss
 from Cryptodome.Util import Padding
-import logging
+from google.protobuf import text_format
+from google.protobuf.message import DecodeError
+
+from pywidevine.cdm.formats import wv_proto2_pb2 as wv_proto2
+from pywidevine.cdm.key import Key
+from pywidevine.cdm.session import Session
+
 
 class Cdm:
     def __init__(self):

--- a/pywidevine/cdm/deviceconfig.py
+++ b/pywidevine/cdm/deviceconfig.py
@@ -1,6 +1,7 @@
+import random
+
 from config import DEFAULT_CDMS
 from libraries import Library
-import random
 
 
 class DeviceConfig:

--- a/pywidevine/cdm/formats/wv_proto2_pb2.py
+++ b/pywidevine/cdm/formats/wv_proto2_pb2.py
@@ -2,13 +2,15 @@
 # source: pywidevine/cdm/formats/wv_proto2.proto
 
 import sys
+
 _b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
-from google.protobuf.internal import enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pb2
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
+from google.protobuf.internal import enum_type_wrapper
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()

--- a/pywidevine/cdm/formats/wv_proto3_pb2.py
+++ b/pywidevine/cdm/formats/wv_proto3_pb2.py
@@ -2,13 +2,15 @@
 # source: wv_proto3.proto
 
 import sys
+
 _b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
-from google.protobuf.internal import enum_type_wrapper
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pb2
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-from google.protobuf import descriptor_pb2
+from google.protobuf.internal import enum_type_wrapper
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()

--- a/pywidevine/cdm/key.py
+++ b/pywidevine/cdm/key.py
@@ -1,5 +1,6 @@
 import binascii
 
+
 class Key:
     def __init__(self, kid, type, key, permissions=[]):
         self.kid = kid

--- a/pywidevine/cdm/vmp.py
+++ b/pywidevine/cdm/vmp.py
@@ -1,5 +1,7 @@
 try:
-  from google.protobuf.internal.decoder import _DecodeVarint as _di # this was tested to work with protobuf 3, but it's an internal API (any varint decoder might work)
+  from google.protobuf.internal.decoder import \
+      _DecodeVarint as \
+      _di  # this was tested to work with protobuf 3, but it's an internal API (any varint decoder might work)
 except ImportError:
   # this is generic and does not depend on pb internals, however it will decode "larger" possible numbers than pb decoder which has them fixed
   def LEB128_decode(buffer, pos, limit = 64):

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,11 @@
 import logging
 import logging.handlers
-from coloredlogs import ColoredFormatter
 from enum import Enum
 
-from config import LOG_DATE_FORMAT, LOG_FORMAT, LOG_LEVEL, WVK_LOG_FILE_PATH, WZ_LOG_FILE_PATH
+from coloredlogs import ColoredFormatter
+
+from config import (LOG_DATE_FORMAT, LOG_FORMAT, LOG_LEVEL, WVK_LOG_FILE_PATH,
+                    WZ_LOG_FILE_PATH)
 
 
 class APIAction(Enum):


### PR DESCRIPTION
This fixes their order to be concise and efficient readability.

The order is:
```
<standardlib>
<external>
<local>
```